### PR TITLE
メッセージの送信数/既読数を記録、表示する

### DIFF
--- a/app/models/transception.rb
+++ b/app/models/transception.rb
@@ -1,0 +1,2 @@
+class Transception < ApplicationRecord
+end

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <div class="stat">
-        <p>送信済合計 1234 / 既読数合計 998</p>
+        <p>送信済合計 <%= @pushed_count %> / 既読数合計 <%= @is_read %></p>
       </div>
 
       <div class="add_message">

--- a/db/migrate/20201106032959_create_transceptions.rb
+++ b/db/migrate/20201106032959_create_transceptions.rb
@@ -1,0 +1,11 @@
+class CreateTransceptions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transceptions do |t|
+      t.string :conversation_id, null: false
+      t.boolean :is_read, default: false
+      t.boolean :is_deleted, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_05_092952) do
+ActiveRecord::Schema.define(version: 2020_11_06_032959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,14 @@ ActiveRecord::Schema.define(version: 2020_11_05_092952) do
     t.integer "message_id", null: false
     t.time "time", null: false
     t.integer "in_x_days", null: false
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "transceptions", force: :cascade do |t|
+    t.string "conversation_id", null: false
+    t.boolean "is_read", default: false
     t.boolean "is_deleted", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/test/fixtures/transceptions.yml
+++ b/test/fixtures/transceptions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  conversation_id: MyString
+  is_read: false
+  is_deleted: false
+
+two:
+  conversation_id: MyString
+  is_read: false
+  is_deleted: false

--- a/test/models/transception_test.rb
+++ b/test/models/transception_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TransceptionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
* テーブル、transceptionを作成した
* 既読数は、一つ一つのメッセージの既読を取得できない(送信メッセージと受信メッセージの紐付けができない)ので、userがbotからのメッセージを開いたら、それまでに溜めたメッセージがすべて既読になる仕様にした(userごとの切り分けは可能)