### PR TITLE
メッセージ画面にバリデーションを掛ける

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem "rubocop"
   gem "rubocop-performance"
   gem "rubocop-rails"
+  gem "awesome_print"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    awesome_print (1.8.0)
     bindex (0.8.1)
     bootsnap (1.4.9)
       msgpack (~> 1.0)
@@ -282,6 +283,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -27,6 +27,14 @@
   }
 }
 
+.message-form {
+  &__errors {
+    padding-left: 1rem;
+    color: red;
+  }
+}
+
+
 .message-body {
   width:  30rem;
   margin: 0 auto;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,75 +1,38 @@
 # frozen_string_literal: true
 
 class MessagesController < ApplicationController
+  before_action :set_workspace, only: [:new, :create, :edit, :update]
+  before_action :set_channel, only: [:new, :create, :edit, :update]
+
   include CurlBuilder
   def new
-    @channel = params[:channel_id]
     @message = Message.new
     @message.build_push_timing
-    p "-------"
-    p ENV["OAUTH_BOT_TOKEN"]
   end
 
   def create
-    x_days_time = x_days_time(params)
-    content = content(params)
-
-    message = Message.new
-    message.channel_id = params[:channel_id]
-    message.message = content[:text] unless content[:text].empty?
-    message.image = content[:image] if content[:image].present?
-    message.save!
-
-    push_timing = PushTiming.new
-    push_timing.message_id = message.id
-    push_timing.in_x_days = x_days_time[:in_x_days]
-    push_timing.time = Time.parse(x_days_time[:time])
-    push_timing.save!
-
-    channel_id = params[:channel_id]
-    members = channel_members(channel_id)
-
-    members.each do |member|
-      participation_datetime = participation_datetime(member, channel_id)
-      push_datetime = push_datetime(participation_datetime, x_days_time)
-      current_datetime = Time.now
-
-      if push_datetime > current_datetime
-        schedule_message(member, push_datetime, message)
-      end
+    @message = Message.new(message_params)
+    if @message.save
+      build_message(@message)
+    else
+      render action: "new"
     end
-
   end
 
   def edit
     @message = Message.find(params[:id])
-    @channel = params[:channel_id]
   end
 
   def update
-    message = Message.find(params[:id])
-    message_push_timing = Message.find(params[:id]).push_timing
+    @message = Message.find(params[:id])
+    if params[:delete_image]
+      @message.image = nil
+    end
 
-    x_days_time = x_days_time(params)
-    content = content(params)
-
-    message.update(message: content[:text]) unless content[:text].empty?
-    message.update(image: content[:image]) if content[:image].present?
-    message.update(image: nil) if params["delete_image"] == "true"
-
-    message_push_timing.update(in_x_days: x_days_time[:in_x_days], time: x_days_time[:time])
-
-    channel_id = params[:channel_id]
-    members = channel_members(channel_id)
-
-    members.each do |member|
-      participation_datetime = participation_datetime(member, channel_id)
-      push_datetime = push_datetime(participation_datetime, x_days_time)
-      current_datetime = Time.now
-
-      if push_datetime > current_datetime
-        schedule_message(member, push_datetime, message)
-      end
+    if @message.update(message_params)
+      build_message(@message)
+    else
+      render action: "edit"
     end
   end
 
@@ -80,9 +43,19 @@ class MessagesController < ApplicationController
 
   private
 
-    def channel_members(channel_id)
-      members = Channel.find(channel_id).companions.map(&:slack_user_id)
-      members
+    def build_message(message)
+      x_days_time = x_days_time(params)
+      members = Channel.find(@channel.id).companions
+
+      members.each do |member|
+        participation_datetime = member.participations.find_by(channel_id: @channel.id).created_at
+        push_datetime = push_datetime(participation_datetime, x_days_time)
+        current_datetime = Time.now
+
+        if push_datetime > current_datetime
+          schedule_message(member.slack_user_id, push_datetime, message)
+        end
+      end
     end
 
     def x_days_time(params)
@@ -95,19 +68,6 @@ class MessagesController < ApplicationController
 
       x_days_time.store(:time, "#{time_hour}:#{time_minute}:#{time_second}")
       x_days_time
-    end
-
-    def content(params)
-      content = {}
-      content.store(:text, params[:message][:message])
-      content.store(:image, params[:message][:image])
-      content
-    end
-
-    def participation_datetime(member, channel_id)
-      companion = Companion.find_by(slack_user_id: member)
-      participation_datetime = companion.participations.where(companion_id: companion.id).find_by(channel_id: channel_id).created_at
-      participation_datetime
     end
 
     def push_datetime(participation_datetime, x_days_time)
@@ -125,7 +85,19 @@ class MessagesController < ApplicationController
         curl_exec(base_url: "https://slack.com/api/chat.scheduleMessage",
                   params: { "token": bot_token, "channel": member, "post_at": push_datetime.to_i, "text": message.message })
       end
-
     end
 
+    def message_params
+      params.require(:message).permit(:message, :image,
+                                    push_timing_attributes: [:id, :in_x_days, :time])
+        .merge(channel_id: @channel.id)
+    end
+
+    def set_workspace
+      @workspace = Workspace.find(params[:workspace_id])
+    end
+
+    def set_channel
+      @channel = Channel.find(params[:channel_id])
+    end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,4 +5,6 @@ class Message < ApplicationRecord
   belongs_to :channel
   accepts_nested_attributes_for :push_timing
   mount_uploader :image, ImageUploader
+
+  validates :message, presence: true
 end

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,0 +1,36 @@
+<div class="message-body">
+  <%= form_with(model: [workspace, channel, message], class: "message-form", local: true) do |m| %>
+    <% if message.errors.any? %>
+      <ul class="message-form__errors">
+        <% message.errors.full_messages.each do |error| %>
+          <li class="message-form__error"><%= error %></li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <h4 class="message-form__title-timing">送信タイミング *</h4>
+    チャンネル登録して
+    <%= m.fields_for :push_timing do |p| %>
+      <%= p.select :in_x_days, x_days_after %>日後の
+      <%= p.time_select :time, {prompt: false, ignore_date: true, include_seconds: true, minute_step: 1} %>に送信する
+    <% end %>
+
+    <h4 class="message-form__title-message">メッセージ *</h4>
+    <p><%= m.text_area :message, size: "60x12", class: "message-form__textarea" %></p>
+    <p><%= m.label :image, "ここをクリックして画像を選択" %>
+      <%= m.file_field :image, onchange: 'previewFileWithId()', accept: 'image/*', class: "hidden" %></p>
+      <% if @message.image_url.present? %>
+        <p><%= image_tag(@message.image_url, {id: 'preview', class: "message-form__preview-img"}) %></p>
+      <% else %>
+        <p><img id="preview" class="message-form__preview-img"></p>
+      <% end %>
+    <p><%= button_tag "画像を削除する", type: "button", id: "deleteImg", class: "message-form__button-delete-img" %></p>
+    <p><%= check_box_tag "delete_image", true, false, id: "delete_check", class: "hidden" %></p>
+
+    <div class="message-form__button-submit">
+      <%= m.submit "テスト送信", class: "message-form__button-test-submit" %>
+      <%= m.submit "postする", class: "message-form__button-commit" %>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -6,86 +6,45 @@
     </h3>
   </div>
 
-  <div class="message-body">
-    <%= form_with(model: @message, url: workspace_channel_message_path, class: "message-form") do |m| %>
-
-      <h4 class="message-form__title-timing">送信タイミング *</h4>
-      チャンネル登録して
-
-      <%= m.fields_for :push_timing do |p| %>
-        <%= p.select :in_x_days, x_days_after %>日後の
-        <%= p.time_select :time, {prompt: false, ignore_date: true, include_seconds: true, minute_step: 1} %>に送信する
-      <% end %>
-
-      <h4 class="message-form__title-message">メッセージ *</h4>
-      <p><%= m.text_area :message, size: "60x12", class: "message-form__textarea" %></p>
-      <p><%= m.label :image, "ここをクリックして画像を選択" %>
-        <%= m.file_field :image, onchange: 'previewFileWithId()', accept: 'image/*', class: "hidden" %></p>
-      <% if @message.image_url.present? %>
-        <p><%= image_tag(@message.image_url, {id: 'preview', class: "message-form__preview-img"}) %></p>
-      <% else %>
-        <p><img id="preview" class="message-form__preview-img"></p>
-      <% end %>
-      <p><%= button_tag "画像を削除する", type: "button", id: "deleteImg", class: "message-form__button-delete-img" %></p>
-      <p><%= check_box_tag "delete_image", true, false, id: "delete_check", class: "hidden" %></p>
-
-      <div class="message-form__button-submit">
-        <input type="submit" value="テスト送信" class="message-form__button-test-submit">
-        <input type="submit" name="commit" value="postする" data-disable-with="postする" class="message-form__button-commit">
-      </div>
-
-    <% end %>
-  </div>
-</div>
+  <%= render 'form', workspace: @workspace, channel: @channel, message: @message %>
 
 </div>
-
-
-
-
-
 
 <script>
-  //初期値
-  var preview = document.getElementById("preview");
-  if (preview.src === "" || preview.src === null) {
-      document.getElementById("deleteImg").style.display = "none";
-  }
+    //初期値
+    var preview = document.getElementById("preview");
+    if (preview.src === "" || preview.src === null) {
+        document.getElementById("deleteImg").style.display = "none";
+    }
 
-  function previewFileWithId() {
-      const target = this.event.target;
-      const file = target.files[0];
-      const reader  = new FileReader();
-      console.log(target.files.length);
-      reader.onloadend = function () {
-          // preview.src = reader.result;
-          document.getElementById("preview").src = reader.result;
-          document.getElementById("deleteImg").style.display = "block";
-          // localImageWidth(reader.result);
-          document.getElementById("delete_check").checked = false;
+    function previewFileWithId() {
+        const target = this.event.target;
+        const file = target.files[0];
+        const reader  = new FileReader();
+        console.log(target.files.length);
+        reader.onloadend = function () {
+            document.getElementById("preview").src = reader.result;
+            document.getElementById("deleteImg").style.display = "block";
+            document.getElementById("delete_check").checked = false;
 
-      }
-      if (file) {
-          reader.readAsDataURL(file);
-      } else {
-          document.getElementById("preview").src = '';
-          document.getElementById("deleteImg").style.display = "none";
-      }
-  }
+        }
+        if (file) {
+            reader.readAsDataURL(file);
+        } else {
+            document.getElementById("preview").src = '';
+            document.getElementById("deleteImg").style.display = "none";
+        }
+    }
 
-  function deleteImg() {
-      document.getElementById("preview").src = '';
-  }
+    var deleteBtn = document.getElementById("deleteImg");
+    deleteBtn.addEventListener("click", function() {
+        var result = window.confirm("本当に削除しますか？");
 
-  var deleteBtn = document.getElementById("deleteImg");
-  deleteBtn.addEventListener("click", function() {
-      var result = window.confirm("本当に削除しますか？");
-
-      if (result) {
-          document.getElementById("preview").src = '';
-          document.getElementById("delete_check").checked = true;
-          document.getElementById("deleteImg").style.display = "none";
-      } else {
-      }
-  })
+        if (result) {
+            document.getElementById("preview").src = '';
+            document.getElementById("delete_check").checked = true;
+            document.getElementById("deleteImg").style.display = "none";
+        } else {
+        }
+    })
 </script>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -6,31 +6,8 @@
     </h3>
   </div>
 
-  <div class="message-body">
-    <%= form_with(model: @message, url: workspace_channel_messages_path, class: "message-form", local: true) do |m| %>
-      <h4 class="message-form__title-timing">送信タイミング *</h4>
-      チャンネル登録して
+  <%= render 'form', workspace: @workspace, channel: @channel, message: @message %>
 
-      <%= m.fields_for :push_timing do |p| %>
-        <%= p.select :in_x_days, x_days_after %>日後の
-        <%= p.time_select :time, {prompt: false, ignore_date: true, include_seconds: true, minute_step: 1} %>に送信する
-      <% end %>
-
-      <h4 class="message-form__title-message">メッセージ *</h4>
-      <p><%= m.text_area :message, size: "60x12", class: "message-form__textarea" %></p>
-      <p><%= m.label :image, "ここをクリックして画像を選択" %>
-        <%= m.file_field :image, onchange: 'previewFileWithId()', accept: 'image/*', class: "hidden" %></p>
-      <p><img id="preview" class="message-form__preview-img"></p>
-      <p><%= button_tag "画像を削除する",type: "button", id: "deleteImg", class: "message-form__button-delete-img" %></p>
-      <p><%= check_box_tag "delete_image", true, false, id: "delete_check", class: "hidden" %></p>
-
-      <div class="message-form__button-submit">
-        <input type="submit" value="テスト送信" class="message-form__button-test-submit">
-        <input type="submit" name="commit" value="postする" data-disable-with="postする" class="message-form__button-commit">
-      </div>
-
-    <% end %>
-  </div>
 </div>
 
 <script>
@@ -46,10 +23,8 @@
         const reader  = new FileReader();
         console.log(target.files.length);
         reader.onloadend = function () {
-            // preview.src = reader.result;
             document.getElementById("preview").src = reader.result;
             document.getElementById("deleteImg").style.display = "block";
-            // localImageWidth(reader.result);
             document.getElementById("delete_check").checked = false;
 
         }
@@ -59,10 +34,6 @@
             document.getElementById("preview").src = '';
             document.getElementById("deleteImg").style.display = "none";
         }
-    }
-
-    function deleteImg() {
-        document.getElementById("preview").src = '';
     }
 
     var deleteBtn = document.getElementById("deleteImg");

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,9 @@ module SlackDeStep
     # the framework and any gems in your application.
     config.time_zone = "Tokyo"
     config.active_record.default_timezone = :local
+
+    # i18n
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*', '*.yml').to_s]
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,34 @@
+ja:
+  activerecord:
+    models:
+      message: メッセージ
+    attributes:
+      message:
+        message: メッセージ
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください


### PR DESCRIPTION
* locale > ja.ymlファイル作成(validation日本語用)
* issue「メッセージ編集時、日時に初期値を入れる」も対応
* 既存メッセージ(送信済)を編集し画像を削除した場合、過去に送信した画像が全て削除される事が判明(AWS上のファイルを削除している事と同義)。別issueを立てて対策する
    * 望ましい挙動は、送信済のメッセージを編集して画像を削除しても、過去に送信したメッセージ内に含まれる画像は「消えない」
