### PR TITLE
app_home_opened イベント発生時に起こるNameErrorを解決する

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -82,7 +82,6 @@ class HomesController < ApplicationController
       end
 
     when "app_home_opened"
-      Channel.new(app_id: app_id, slack_channel_id: channel[:id], name: channel[:name], member_count: 0).save!
       transception = Transception.where(conversation_id: channel)
       transception.update(is_read: true)
     end


### PR DESCRIPTION
* rubymineの誤操作で不要な行が入った様子
* 該当部分を削除