### PR TITLE
チャンネルごとに送信数と既読数を記録、表示する

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -8,8 +8,10 @@ class ChannelsController < ApplicationController
   def show
     @channels = App.find_by(workspace_id: @workspace.id).channels
 
-    @pushed_count = Transception.count
-    @is_read = Transception.where(is_read: true).count
+    post_messages = Transception.where(message_id: @channel.messages.map(&:id))
+    @pushed_count = post_messages.count
+    @is_read = post_messages.where(is_read: true).count
+
     bot_token = @workspace.app.oauth_bot_token
     bot_user_id = @workspace.app.bot_user_id
 

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -64,7 +64,7 @@ class HomesController < ApplicationController
       companion = Companion.find_by(slack_user_id: user)
       channel_to_leave = Channel.find_by(slack_channel_id: channel)
       participation = Participation.find_by(companion_id: companion.id, channel_id: channel_to_leave.id)
-      participation.destroy
+      participation.destroy unless participation.nil?
       # member_count(channel)
 
     when "channel_left"
@@ -72,13 +72,14 @@ class HomesController < ApplicationController
       companion = Companion.find_by(slack_user_id: bot_user_id)
       channel_to_leave = Channel.find_by(slack_channel_id: channel)
       participation = Participation.find_by(companion_id: companion.id, channel_id: channel_to_leave.id)
-      participation.destroy
+      participation.destroy unless participation.nil?
       # member_count(channel)
 
     when "message"
       # messageで受けるイベントは複数ある為,bot_user_idで選別
       if App.exists?(bot_user_id: user) && params[:event][:subtype].nil?
-        Transception.new(conversation_id: channel).save!
+        message_id = params[:event][:blocks][0][:block_id].to_i
+        Transception.new(conversation_id: channel, message_id: message_id).save!
       end
 
     when "app_home_opened"

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -80,13 +80,13 @@ class MessagesController < ApplicationController
       bot_token = @workspace.app.oauth_bot_token
       if params[:post_now]
         curl_exec(base_url: "https://slack.com/api/chat.postMessage",
-                  params: { "token": bot_token, "channel": member, "text": message.message })
+                  params: { "token": bot_token, "channel": member, "blocks": "[{\"block_id\": \"#{message.id}\", \"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\" }}]" })
       elsif  message.image_url
         curl_exec(base_url: "https://slack.com/api/chat.scheduleMessage",
-                  params: { "token": bot_token, "channel": member, "post_at": push_datetime.to_i, "blocks": "[{\"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\"}, \"block_id\": \"text1\"}, {\"type\": \"image\", \"title\": {\"type\": \"plain_text\",\"text\": \"pitcure\"}, \"image_url\": \"#{message.image_url}\", \"block_id\": \"image4\",\"alt_text\": \"pitcure here\"}]" })
+                  params: { "token": bot_token, "channel": member, "post_at": push_datetime.to_i, "blocks": "[{\"block_id\": \"#{message.id}\", \"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\"}}, {\"type\": \"image\", \"title\": {\"type\": \"plain_text\",\"text\": \"pitcure\"}, \"image_url\": \"#{message.image_url}\", \"block_id\": \"image4\",\"alt_text\": \"pitcure here\"}]" })
       else
         curl_exec(base_url: "https://slack.com/api/chat.scheduleMessage",
-                  params: { "token": bot_token, "channel": member, "post_at": push_datetime.to_i, "text": message.message })
+                  params: { "token": bot_token, "channel": member, "post_at": push_datetime.to_i, "blocks": "[{\"block_id\": \"#{message.id}\", \"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\" }}]" })
       end
     end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,6 +2,7 @@
 
 class Message < ApplicationRecord
   has_one :push_timing, dependent: :destroy
+  has_many :transceptions, dependent: :destroy
   belongs_to :channel
   accepts_nested_attributes_for :push_timing
   mount_uploader :image, ImageUploader

--- a/app/models/transception.rb
+++ b/app/models/transception.rb
@@ -1,2 +1,3 @@
 class Transception < ApplicationRecord
+  belongs_to :message
 end

--- a/db/migrate/20201118070302_add_column_message_id_to_transceptions.rb
+++ b/db/migrate/20201118070302_add_column_message_id_to_transceptions.rb
@@ -1,0 +1,6 @@
+class AddColumnMessageIdToTransceptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :transceptions, :message_id, :integer, null: false, default: 1
+    change_column_default :transceptions, :message_id, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_014916) do
+ActiveRecord::Schema.define(version: 2020_11_18_070302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2020_11_17_014916) do
     t.boolean "is_deleted", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "message_id", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
* カラム`message_id`を追加
* メッセージ送信時に、メッセージ送信のapiメソッドのoptionでmessage idを付与し、送信と受信のメッセージを紐付けている
* 若干トリッキーな方法かも知れないが、他に考えつかなかった
    * この方法が許容できなければ「送信数 / 既読数」の表示自体をなくす方向で考えたい