### PR TITLE
テスト送信できるようにする

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -76,10 +76,14 @@ class HomesController < ApplicationController
       member_count(channel)
 
     when "message"
+      message_id = params[:event][:blocks][0][:block_id]
       # messageで受けるイベントは複数ある為,bot_user_idで選別
-      if App.exists?(bot_user_id: user) && params[:event][:subtype].nil?
-        message_id = params[:event][:blocks][0][:block_id].to_i
-        Transception.new(conversation_id: channel, message_id: message_id).save!
+      from_bot = App.exists?(bot_user_id: user)
+      is_subtype = params[:event][:subtype].present?
+      is_test_message = message_id == "test_message" ? true : false
+
+      if from_bot && !is_subtype && !is_test_message
+        Transception.new(conversation_id: channel, message_id: message_id.to_i).save!
       end
 
     when "app_home_opened"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,6 +12,7 @@ class SessionsController < ApplicationController
       user = User.find_or_create_form_auth(oauth_v2_access)
       session[:user] = user
       session[:user_id] = user.id
+      session[:authed_slack_user_id] = JSON.parse(oauth_v2_access[0])["authed_user"]["id"]
       flash[:success] = "ユーザー認証が完了しました。"
       redirect_to workspaces_path
     else

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -26,12 +26,10 @@
       <% end %>
     <p><%= button_tag "画像を削除する", type: "button", id: "deleteImg", class: "message-form__button-delete-img" %></p>
     <p><%= check_box_tag "delete_image", true, false, id: "delete_check", class: "hidden" %></p>
-    <% ##TODO: リリース時、即時postは削除する事 %>
-    <p>post now<%= check_box_tag "post_now", true, false %></p>
 
     <div class="message-form__button-submit">
       <%= m.submit "テスト送信", class: "message-form__button-test-submit" %>
-      <%= m.submit "postする", class: "message-form__button-commit" %>
+      <%= m.submit "登録", class: "message-form__button-commit" %>
     </div>
 
   <% end %>


### PR DESCRIPTION
* 以前対応したissue [テスト用に即時メッセージが届くようにする](https://github.com/sdk-quadra/slack-de-step/issues/216) のコードを流用
* ログインした時のuser idをsessionで仕込み、そのuserのslack user idをcompanionテーブルから引く＝＞userテーブルとcompanionテーブルをリレーションしようとしたが、構造が複雑になる為回避。単純にslack user idをsessionに仕込む事にした
    * その仕込んだslack user idに対して、メッセージ画面からメッセージ設定者に即時メッセージを送っている