### PR TITLE
新規ログインした時にNotNullViolationエラーが出る

### DIFF
--- a/db/migrate/20201120075504_remove_column_uid_and_provider_from_users.rb
+++ b/db/migrate/20201120075504_remove_column_uid_and_provider_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveColumnUidAndProviderFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :uid, :string
+    remove_column :users, :provider, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_19_075456) do
+ActiveRecord::Schema.define(version: 2020_11_20_075504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,8 +100,6 @@ ActiveRecord::Schema.define(version: 2020_11_19_075456) do
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "name"
-    t.string "uid", null: false
-    t.string "provider", null: false
     t.boolean "is_deleted", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
* omniauth-slackでのログインをsign in with slackに切り替えたので、uidとproviderカラムは不要となった
* 上記のカラムを削除する事でログインできるようになった