### PR TITLE
channel参加者にメッセージを送れない

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -76,13 +76,14 @@ class HomesController < ApplicationController
       member_count(channel)
 
     when "message"
+      return if params[:event][:subtype].present?
+
       message_id = params[:event][:blocks][0][:block_id]
       # messageで受けるイベントは複数ある為,bot_user_idで選別
       from_bot = App.exists?(bot_user_id: user)
-      is_subtype = params[:event][:subtype].present?
       is_test_message = message_id == "test_message" ? true : false
 
-      if from_bot && !is_subtype && !is_test_message
+      if from_bot && !is_test_message
         Transception.new(conversation_id: channel, message_id: message_id.to_i).save!
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,11 +77,18 @@ class User < ApplicationRecord
         channel.name = conversation["name"]
         channel.member_count = 0
         channel.name == "general" ? channel.display = true : channel.display = false
+
+        join_to_channel(oauth_bot_token, conversation)
       end
       # botをpublic channelに参加させる
       curl_exec(base_url: "https://slack.com/api/conversations.join", headers: { "Authorization": "Bearer " + oauth_bot_token },
                 params: { "channel": conversation["id"] })
     end
+  end
+
+  def self.join_to_channel(bot_token, channel)
+    curl_exec(base_url: "https://slack.com/api/conversations.join", headers: { "Authorization": "Bearer " + bot_token },
+              params: { "channel": channel[:id] })
   end
 
   def self.create_companions(auth, app)


### PR DESCRIPTION
* slack apiでscope権限を全てbotで管理する事にしたのが原因
* 新規ログイン時にbotをchannelに仕込み、channel参加者を検知するようにした