### PR TITLE
同じchannelが重複登録される原因調査と対応

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -114,7 +114,14 @@ class HomesController < ApplicationController
   def create_channel(api_app, channel)
     api_app_id = App.find_by(api_app_id: api_app).id
     name = channel_name(api_app, channel[:id])
-    Channel.create(app_id: api_app_id, name: name, slack_channel_id: channel[:id], member_count: 0)
+
+    Channel.find_or_create_by!(app_id: api_app_id, slack_channel_id: channel[:id]) do |c|
+      c.app_id = api_app_id
+      c.name = name
+      c.slack_channel_id = channel[:id]
+      c.member_count = 0
+    end
+
   end
 
   def join_to_channel(bot_token, channel)


### PR DESCRIPTION
* 何らかの理由でchannelに参加した時のイベントを受信できず、その後退出して再度参加すると同じchannelでダブって登録される可能性がある
* おそらく開発段階で、channel参加のイベントを受信する機能だけを先に付け、退出のイベント受信機能を別で付けたのではないか
* 一応登録channelがダブらないように、find_or_create_byに変更した