### PR TITLE
画像メッセージのテストを修正する

### DIFF
--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -2,6 +2,15 @@
 
 .lp {
   margin: 0 auto;
+  &__flash {
+    text-align: center;
+    padding: 1rem;
+    color: $white;
+    background-color: $slackgreen;
+  }
+  &__flash-login-failed {
+    background-color: $slackpink;
+  }
   &__header {
     background-color: $slackpurple;
   }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -16,6 +16,8 @@ class MessagesController < ApplicationController
   def create
     @message = Message.new(message_params)
 
+    @message.image = nil if params["delete-image"]
+
     if params[:commit] == "テスト送信" && @message.valid?
       test_message(@bot_token, @message)
       flash.now[:test_submit] = true
@@ -35,7 +37,7 @@ class MessagesController < ApplicationController
   def update
     @message = Message.find(params[:id])
 
-    @message.image = nil if params[:delete-image]
+    @message.image = nil if params["delete-image"]
 
     if params[:commit] == "テスト送信" && @message.update(message_params)
       test_message(@bot_token, @message)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -22,8 +22,7 @@ class MessagesController < ApplicationController
       render action: "new"
     elsif params[:commit] == "登録" && @message.save
       build_message(@bot_token, @message)
-      # redirect_to workspace_channel_path(@workspace, @channel), flash: { commit_message: true }
-      redirect_to workspace_channel_path(@workspace, @channel)
+      redirect_to workspace_channel_path(@workspace, @channel), flash: { commit_message: true }
     else
       render action: "new"
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,15 +14,14 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       session[:workspace_id] = JSON.parse(oauth_v2_access[0])["team"]["id"]
       session[:authed_slack_user_id] = JSON.parse(oauth_v2_access[0])["authed_user"]["id"]
-      flash[:success] = "ユーザー認証が完了しました。"
       redirect_to workspaces_path
     else
-      flash.now[:danger] = "ログインに失敗しました"
+      redirect_to root_path, flash:  { login_failed: "ログインに失敗しました"}
     end
   end
 
   def destroy
     session[:user_id] = nil
-    redirect_to root_path, notice: "ログアウトしました"
+    redirect_to root_path, flash: { logout: "ログアウトしました"}
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,4 +1,10 @@
 <div class="lp">
+  <% flash.each do |k, v| %>
+    <div class="lp__flash <%= "lp__flash-login-failed" if k == "login_failed" %>">
+      <div class="lp__flash-text "><%= v %></div>
+    </div>
+  <% end %>
+
   <div class="lp__header">
     <div class="lp__header-items">
       <h3 class="lp__logo">

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -155,7 +155,8 @@ RSpec.describe "messages", type: :system do
 
     click_button "削除する"
     click_button "登録"
-    expect(find(".channel-message-data__image")).to be_visible
+
+    expect(page).to have_no_selector(".channel-message-data__image")
   end
 
   it "画像選択時、プレビューが表示される事", js: true do


### PR DESCRIPTION
* paramsをシンボルで記述していたのが原因
* [session controllerコード修正 #304](https://github.com/sdk-quadra/slack-de-step/issues/304)も同時に行う