### PR TITLE
channel一覧のサイドバーのデザイン修正

### DIFF
--- a/app/assets/stylesheets/channels.scss
+++ b/app/assets/stylesheets/channels.scss
@@ -8,6 +8,7 @@
 
 .channels {
   background-color: $weakgray;
+  padding-bottom: 5rem;
 
   &__workspace-info {
     display: flex;


### PR DESCRIPTION
* channelによる高さがメッセージより多い場合を考慮し、channelの最下部にpaddingが入るようにした