### PR TITLE
メッセージ登録処理中は編集ページを訪問できないようにする

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -32,10 +32,12 @@ class MessagesController < ApplicationController
 
   def edit
     @message = Message.find(params[:id])
+    inaccessible_while_processing(@message)
   end
 
   def update
     @message = Message.find(params[:id])
+    inaccessible_while_processing(@message)
 
     @message.image = nil if params["delete-image"]
 
@@ -55,10 +57,11 @@ class MessagesController < ApplicationController
   end
 
   def destroy
-    message_id = params[:id]
+    @message = Message.find(params[:id])
+    inaccessible_while_processing(@message)
 
-    build_delete_message(@bot_token, message_id)
-    Message.destroy(message_id)
+    build_delete_message(@bot_token, @message.id)
+    @message.destroy
     redirect_to workspace_channel_path(@workspace, @channel)
   end
 
@@ -67,6 +70,10 @@ class MessagesController < ApplicationController
       params.require(:message).permit(:message, :image,
                                       push_timing_attributes: [:id, :in_x_days, :time])
           .merge(channel_id: @channel.id)
+    end
+
+    def inaccessible_while_processing(message)
+      redirect_to workspace_channel_path(@workspace, @channel) if message.modifiable == false
     end
 
     def set_workspace

--- a/db/migrate/20201229040756_remove_column_api_app_id_from_apps.rb
+++ b/db/migrate/20201229040756_remove_column_api_app_id_from_apps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveColumnApiAppIdFromApps < ActiveRecord::Migration[6.0]
   def change
     remove_column :apps, :api_app_id, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_12_29_040756) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,5 +102,4 @@ ActiveRecord::Schema.define(version: 2020_12_29_040756) do
     t.string "name", null: false
     t.string "icon_url", null: false
   end
-
 end


### PR DESCRIPTION
* 同じ記述がmessage controllerの`update`や`edit`にあるが、`before_action`を使うより個別にした方が分かりやすいと考え、別に書いてある