### PR TITLE
userを招待した場合にuserが重複して登録される

### DIFF
--- a/app/controllers/events/member_joined_channel.rb
+++ b/app/controllers/events/member_joined_channel.rb
@@ -15,8 +15,8 @@ class Events::MemberJoinedChannel
     return if params[:authorizations][0][:is_bot] == "true"
 
     # 新規参加userの場合
-    companion = Companion.find_or_create_by!(slack_user_id: user) do |c|
-      app_id = Workspace.find_by(slack_ws_id: team).app.id
+    app_id = Workspace.find_by(slack_ws_id: team).app.id
+    companion = Companion.find_or_create_by!(app_id: app_id, slack_user_id: user) do |c|
       c.app_id = app_id
       c.slack_user_id = user
     end


### PR DESCRIPTION
* `find_or_create_by`で`app_id`と`slack_user_id`の2つを見るようにした