### PR TITLE
メッセージ設定時に対象者がいなければ即編集可能にする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: slack_de_step_test
 
+      - image: redis
+
     working_directory: ~/slack-de-step
     environment:
       TZ: "Asia/Tokyo"

--- a/app/controllers/concerns/message_builder.rb
+++ b/app/controllers/concerns/message_builder.rb
@@ -19,8 +19,6 @@ module MessageBuilder
   end
 
   def build_message(bot_token, message)
-    message.update(modifiable: false)
-
     in_x_days = params[:message][:push_timing_attributes][:in_x_days]
     time = params[:message][:push_timing_attributes][:time]
 
@@ -42,6 +40,8 @@ module MessageBuilder
   end
 
   def schedule_message(bot_token, member, push_datetime, message, index = 1)
+    # 予約が完了するまで編集不可にする
+    message.update(modifiable: false)
     ScheduleMessage.perform_in(index*MIN_POLLING_TIME.seconds, bot_token, member.slack_user_id, push_datetime.to_i, message.id)
   end
 

--- a/app/workers/schedule_message.rb
+++ b/app/workers/schedule_message.rb
@@ -24,7 +24,7 @@ class ScheduleMessage
     # queueがなくなったら修正可能にする
     queues = Sidekiq::ScheduledSet.new
 
-    if queues.size == 0
+    if queues.size <= 0
       message.update(modifiable: true)
     end
   end

--- a/spec/factories/participations.rb
+++ b/spec/factories/participations.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :participation do
     sequence(:channel_id) { 1 }
     sequence(:companion_id) { 1 }
+    sequence(:created_at) { Time.now }
   end
 end

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "messages", type: :system do
     @possession = FactoryBot.create(:possession, user_id: @user.id, workspace_id: @workspace.id)
     @app = FactoryBot.create(:app, workspace_id: @workspace.id)
     @channel = FactoryBot.create(:channel, app_id: @app.id)
+    @companion = FactoryBot.create(:companion, app_id: @app.id)
+    @participation = FactoryBot.create(:participation, channel_id: @channel.id, companion_id: @companion.id)
   end
 
   it "テキストメッセージを新規登録できる事" do


### PR DESCRIPTION
* `main`とマージすると
```
 Redis::CannotConnectError:
       Error connecting to Redis on localhost:6379 (Errno::EADDRNOTAVAIL)
```
が出た。
* circleCIの設定ファイルに`image: redis`を追記した