### PR TITLE
アプリのicon、nameをDB保存する

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -18,8 +18,9 @@ class ChannelsController < ApplicationController
     bot_user_id = @workspace.app.bot_user_id
 
     users_info = users_info(bot_token, bot_user_id)
-    @user_info_realname = JSON.parse(users_info[0])["user"]["real_name"]
-    @user_info_profile_image = JSON.parse(users_info[0])["user"]["profile"]["image_192"]
+    @app_info = {}
+    @app_info.store(:real_name, JSON.parse(users_info[0])["user"]["real_name"])
+    @app_info.store(:icon_url, JSON.parse(users_info[0])["user"]["profile"]["image_192"])
 
     @messages = sort_messages
   end

--- a/app/views/channels/_channel_message.html.slim
+++ b/app/views/channels/_channel_message.html.slim
@@ -4,10 +4,10 @@
       = "#{message.push_timing.in_x_days}日後の#{message.push_timing.time.strftime('%H:%M')}"
 
   .channel-message
-    = image_tag(@user_info_profile_image, class: "channel-message__sender-icon")
+    = image_tag(@app_info[:icon_url], class: "channel-message__sender-icon")
     .channel-message-data
       .channel-message-data__sender-name
-        = @user_info_realname
+        = @app_info[:real_name]
 
       .channel-message-data__content
         = simple_format(message.message)


### PR DESCRIPTION
* アプリ情報変更時にイベントは発生しない事が分かった
* アプリ情報を事前にDB保存しておき、変更時には直接DBを書き換える、という方法があるが、現状それほどapi通信に負荷が掛かっていないので、今のままで変更はしない
* アプリ情報の取得部分のコードを若干最適化した