### PR TITLE
メッセージ内のURLをリンクに置き換える

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,18 +12,15 @@ gem "sass-rails", ">= 6"
 gem "webpacker", "~> 4.0"
 gem "turbolinks", "~> 5"
 # gem "jbuilder", "~> 2.7"
-
 gem "bootsnap", ">= 1.4.2", require: false
 
 gem "carrierwave"
 gem "fog-aws"
-
 gem "redis-namespace"
 gem "sidekiq"
-
 gem "rails-i18n"
-
 gem "slim-rails"
+gem "rinku"
 
 group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
       redis (>= 3.0.4)
     regexp_parser (1.8.2)
     rexml (3.2.4)
+    rinku (2.0.6)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -317,6 +318,7 @@ DEPENDENCIES
   rails (~> 6.0.3, >= 6.0.3.4)
   rails-i18n
   redis-namespace
+  rinku
   rspec-rails
   rubocop
   rubocop-performance

--- a/app/assets/stylesheets/channels.scss
+++ b/app/assets/stylesheets/channels.scss
@@ -154,6 +154,10 @@
   &__content {
     color: $stronggray;
   }
+  &__content > p > a {
+    color: $slackblue;
+    text-decoration: none;
+  }
   &__image {
     max-width: 250px;
     max-height: 250px;

--- a/app/controllers/concerns/slack_api_blocks.rb
+++ b/app/controllers/concerns/slack_api_blocks.rb
@@ -4,22 +4,22 @@ module SlackApiBlocks
   extend ActiveSupport::Concern
 
   def test_blocks_text_with_image(message)
-    blocks = "[{\"block_id\": \"test_message\", \"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\"}}, {\"type\": \"image\", \"title\": {\"type\": \"plain_text\",\"text\": \"pitcure\"}, \"image_url\": \"#{message.image_url}\", \"block_id\": \"image4\",\"alt_text\": \"pitcure here\"}]"
+    blocks = "[{\"block_id\": \"test_message\", \"type\": \"section\",\"text\": {\"type\": \"mrkdwn\", \"text\": \"#{message.message}\"}}, {\"type\": \"image\", \"title\": {\"type\": \"plain_text\",\"text\": \"pitcure\"}, \"image_url\": \"#{message.image_url}\", \"block_id\": \"image4\",\"alt_text\": \"pitcure here\"}]"
     blocks
   end
 
   def test_blocks_text(message)
-    blocks = "[{\"block_id\": \"test_message\", \"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\" }}]"
+    blocks = "[{\"block_id\": \"test_message\", \"type\": \"section\",\"text\": {\"type\": \"mrkdwn\", \"text\": \"#{message.message}\"}}]"
     blocks
   end
 
   def schedule_blocks_text_with_image(message)
-    blocks = "[{\"block_id\": \"#{message.id}\", \"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\"}}, {\"type\": \"image\", \"title\": {\"type\": \"plain_text\",\"text\": \"pitcure\"}, \"image_url\": \"#{message.image_url}\", \"block_id\": \"image4\",\"alt_text\": \"pitcure here\"}]"
+    blocks = "[{\"block_id\": \"#{message.id}\", \"type\": \"section\",\"text\": {\"type\": \"mrkdwn\", \"text\": \"#{message.message}\"}}, {\"type\": \"image\", \"title\": {\"type\": \"plain_text\",\"text\": \"pitcure\"}, \"image_url\": \"#{message.image_url}\", \"block_id\": \"image4\",\"alt_text\": \"pitcure here\"}]"
     blocks
   end
 
   def schedule_blocks_text(message)
-    blocks = "[{\"block_id\": \"#{message.id}\", \"type\": \"section\",\"text\": {\"type\": \"plain_text\", \"text\": \"#{message.message}\" }}]"
+    blocks = "[{\"block_id\": \"#{message.id}\", \"type\": \"section\",\"text\": {\"type\": \"mrkdwn\", \"text\": \"#{message.message}\" }}]"
     blocks
   end
 end

--- a/app/views/channels/_channel_message.html.slim
+++ b/app/views/channels/_channel_message.html.slim
@@ -10,7 +10,7 @@
         = @app_info[:real_name]
 
       .channel-message-data__content
-        = simple_format(message.message)
+        == Rinku.auto_link(simple_format(message.message), :all, 'target="_blank"')
         = image_tag(message.image_url, { class: "channel-message-data__image" }) if message.image_url
 
       .channel-message-data__state

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe "messages", type: :system do
         find("#message_push_timing_attributes_time").set("#{hour}:#{minutes}")
         click_button "テスト送信"
 
-        expect(page).to have_content "テスト送信しました"
+        expect(find("#overlay-test-submit", visible: true)).to be_visible
       end
 
       it "メッセージ登録後、modalが表示される事", js: true do
@@ -244,7 +244,7 @@ RSpec.describe "messages", type: :system do
         find("#message_push_timing_attributes_time").set("#{hour}:#{minutes}")
         click_button "登録"
 
-        expect(page).to have_content "メッセージを登録しました"
+        expect(find("#overlay-commit-message", visible: true)).to be_visible
       end
     end
   end


### PR DESCRIPTION
* httpを含むテキストが、slackで受信した時にリンクになるようにした
* これに伴い、slack de stepのチャンネル > メッセージ一覧画面でも、httpを含むテキストがリンクになるようにした