### PR TITLE
redisのURLを修正する

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails server -p $PORT
+worker: bundle exec sidekiq

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL") { ENV["REDIS_URL"] } %>
   channel_prefix: slack_de_step_production

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: "redis://localhost:6379", namespace: "sidekiq" }
+  config.redis = { url: ENV["REDIS_URL"], namespace: "sidekiq" }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: "redis://localhost:6379", namespace: "sidekiq" }
+  config.redis = { url: ENV["REDIS_URL"], namespace: "sidekiq" }
 end


### PR DESCRIPTION
* 環境変数 `REDIS_URL`を使用
    * nilならdefaultの`localhost:6379`を見に行くので、localでも問題ない