### PR TITLE
環境変数を減らす

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,12 @@ jobs:
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
       - run:
-          name: exec Chromedriver
-          command: chromedriver
-          background: true
+          name: Update Chromedriver
+          command: |
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+            sudo apt-get update
+            sudo apt-get --only-upgrade install google-chrome-stable
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ heroku buttonを使うには、以下の環境変数の情報が必要です↓
 
 ### 環境変数
 
-localで動かすには、以下の環境変数のセットが必要です。
 
 #### slack 情報
 slackとの連携の為。[Create New Appで取得](https://api.slack.com/apps)
@@ -24,10 +23,6 @@ slackとの連携の為。[Create New Appで取得](https://api.slack.com/apps)
 * ENV["SLACK_CLIENT_ID"]
 * ENV["SLACK_CLIENT_SECRET]
 
-#### salt
-slack token暗号化の為。長さは32byte
-
-* ENV["SALTED_KEY"]
 
 #### AWS情報
 画像保存の為。
@@ -35,45 +30,41 @@ slack token暗号化の為。長さは32byte
 * ENV["AWS_ACCESS_KEY"]
 * ENV["AWS_SECRET_ACCESS_KEY"]
 
+----------heroku buttonを使ってアプリを立ち上げる場合、ここから下は herokuにdeployしてから実行してください-------------
+
+
+* herokuの管理画面でdeployしたアプリを選択後、Resourceで
+`worker bundle exec sidekiq`
+をonにしてください
+
+* もしdeploy to herokuの時に設定した環境変数の値を変更したいなら、
+herokuの管理画面のSettingから行ってください
+
 --------
 
 
-
-### メッセージ送信
-多数のメッセージを捌く為、sidekiqを使用
-
-* $ redis-server
-* $ bundle exec sidekiq
----------
-
-
-### イベント受信
-開発時は、slack上で発生したイベントを受信する為に、[ngrok](https://api.slack.com/tutorials/tunneling-with-ngrok) の利用を推奨
-
----------
-
-
-### 送信対象
-SlackとSlack De Stepを連携してから「以降」にチャンネルに参加した人が対象。
-
-連携時、すでにチャンネルに参加している人に対して、遡って対象にする事はできません。
-
-
----------
-
-### テスト
-$ bundle exec rspec spec
-
----------
-
 ### 権限・認証・スコープ
 slack apiの権限・認証・スコープ周りの設定は以下の通りです。
+
+上記の [Create New Appで取得](https://api.slack.com/apps) の時に、OAuth & Permissionsと Event Subscriptions
+を 以下の様に設定してください
 
 この設定を行う時、chromeの翻訳機能でページが日本語化されているとエラーになるので注意してください。
 
 #### OAuth & Permissions
 
-##### Bot Token Scopes
+##### OAuth Tokens & Redirect URLs
+`install to workspace`をクリックして、tokenを発行してください
+
+##### Redirect URLs
+`/auth/slack/callback`を指定してください。
+
+例：`https://your.app.com/auth/slack/callback`
+
+##### Scopes
+スコープには以下を指定してください
+
+###### Bot Token Scopes
 
 * channels:history
 * channels:join
@@ -87,7 +78,7 @@ slack apiの権限・認証・スコープ周りの設定は以下の通りで�
 * users:read
 
 
-##### User Token Scopes
+###### User Token Scopes
 
 * identity.avatar
 * identity.basic
@@ -95,27 +86,105 @@ slack apiの権限・認証・スコープ周りの設定は以下の通りで�
 * identity.team
 
 
+
+
 #### Event Subscriptions
+
+Enable Events をonにしてから、以下を設定してください
+
+##### Request URL
+`/server`を指定してください
+
+例：`https://your.app.com/server`
+
 
 ##### Subscribe to bot events
 
 * app_home_opened
 * channel_created
-* channels:read
 * channel_deleted
-* channels:read
 * channel_left
-* channels:read
 * channel_rename
-* channels:read
 * member_joined_channel
-* channels:read or groups:read
 * member_left_channel
-* channels:read or groups:read
 * message.im
-* im:history
 * team_join
-* users:read
+
+
+-----------------
+
+#### Manage distribution
+
+Manage distributionで`Distribute App`をクリックして、アプリの配布設定をします。
+
+Remove Hard Coded Informationの
+`I’ve reviewed and removed any hard-coded information.`
+にcheckを入れて、`Activate Public Distribution`をクリックしてください
+
+------------
+
+
+以上でアプリを使えるようになっているはずです。
+
+
+もしそれでもページが表示されないなら、環境変数の値が間違っている可能性があります。
+その場合は、herokuの管理画面のsettingから、環境変数を修正してください。
+
+
+
+
+
+
+----------
+
+------------ここから下は、localで動かす際の情報です------------
+
+### メッセージ送信
+多数のメッセージを捌く為、sidekiqを使用しています
+
+* $ redis-server
+* $ bundle exec sidekiq
+---------
+
+
+### イベント受信
+slack上で発生したイベントを受信する為に、[ngrok](https://api.slack.com/tutorials/tunneling-with-ngrok) の利用を推奨
+
+---------
+
+
+### 送信対象
+SlackとSlack De Stepを連携してから「以降」にチャンネルに参加した人が対象。
+
+連携時、すでにチャンネルに参加している人に対して、遡って対象にする事はできません。
+
+
+---------
+
+### テスト
+
+テストを実行するには、特定の環境変数の設定が必要です。
+
+`$ rails c` して以下を行います。
+
+```
+irb> len = ActiveSupport::MessageEncryptor.key_len
+
+irb> salt = SecureRandom.hex(len)
+
+irb> token = "<※注１>"
+
+irb> encrypted_token = App.encrypt_token(salt, token)
+```
+※注１：上記の [Create New Appで取得](https://api.slack.com/apps) の
+OAuth & Permissionsにある、`xoxb-`で始まる Bot User OAuth Access Token を指定してください
+
+
+上記で生成した`salt`を ENV["SALTED_KEY"]に、
+
+`encrypted_token` を ENV["OAUTH_BOT_TOKEN"]に入れてからテストを実行してください
+
+`$ bundle exec rspec spec`
 
 
 ---------

--- a/app/controllers/concerns/crypt_builder.rb
+++ b/app/controllers/concerns/crypt_builder.rb
@@ -3,22 +3,35 @@
 module CryptBuilder
   extend ActiveSupport::Concern
 
-  def encrypt_token(oauth_bot_token)
-    crypt = message_encryptor
+  def encrypt_token(salt, oauth_bot_token)
+    crypt = message_encryptor(salt)
     encrypted_token = crypt.encrypt_and_sign(oauth_bot_token)
     encrypted_token
   end
 
   def decrypt_token(oauth_bot_token)
-    crypt = message_encryptor
+    salt = App.find_by(oauth_bot_token: oauth_bot_token).salt
+    crypt = message_encryptor(salt)
     decrypted_token = crypt.decrypt_and_verify(oauth_bot_token)
     decrypted_token
   end
 
-  def message_encryptor
-    len   = ActiveSupport::MessageEncryptor.key_len
-    key   = ActiveSupport::KeyGenerator.new("oauth_bot_token").generate_key(ENV["SALTED_KEY"], len)
-    crypt = ActiveSupport::MessageEncryptor.new(key)
-    crypt
+  def token_salt
+    len = message_key_len
+    salt = SecureRandom.hex(len)
+    salt
   end
+
+  private
+    def message_encryptor(salt)
+      len = message_key_len
+      key = ActiveSupport::KeyGenerator.new("oauth_bot_token").generate_key(salt, len)
+      crypt = ActiveSupport::MessageEncryptor.new(key)
+      crypt
+    end
+
+    def message_key_len
+      len = ActiveSupport::MessageEncryptor.key_len
+      len
+    end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -81,6 +81,7 @@ class MessagesController < ApplicationController
     end
 
     def set_bot_token
-      @bot_token = decrypt_token(Workspace.find(session[:workspace_id]).app.oauth_bot_token)
+      oauth_bot_token = App.find_by(workspace_id: session[:workspace_id]).oauth_bot_token
+      @bot_token = decrypt_token(oauth_bot_token)
     end
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -8,14 +8,16 @@ class App < ApplicationRecord
 
   def self.create_app(auth, workspace)
     oauth_bot_token = auth["access_token"]
+    salt = token_salt
     bot_user_id = auth["bot_user_id"]
 
-    encrypt_token = encrypt_token(oauth_bot_token)
+    encrypt_token = encrypt_token(salt, oauth_bot_token)
 
     # workspace_idがすでにあれば、更新する。bot_tokenが変わった場合を想定
     app = App.find_or_initialize_by(workspace_id: workspace.id)
     app.update_attributes(
       oauth_bot_token: encrypt_token,
+      salt: salt,
       bot_user_id: bot_user_id
     )
     app

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -4,6 +4,7 @@ class App < ApplicationRecord
   belongs_to :workspace
   has_many :channels, dependent: :destroy
   has_many :companions, dependent: :destroy
+
   extend CryptBuilder
 
   def self.create_app(auth, workspace)

--- a/db/migrate/20210107113825_add_column_salt_to_apps.rb
+++ b/db/migrate/20210107113825_add_column_salt_to_apps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddColumnSaltToApps < ActiveRecord::Migration[6.0]
   def change
     add_column :apps, :salt, :string, null: false, default: ""

--- a/db/migrate/20210107113825_add_column_salt_to_apps.rb
+++ b/db/migrate/20210107113825_add_column_salt_to_apps.rb
@@ -1,0 +1,6 @@
+class AddColumnSaltToApps < ActiveRecord::Migration[6.0]
+  def change
+    add_column :apps, :salt, :string, null: false, default: ""
+    change_column_default :apps, :salt, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_02_010427) do
+ActiveRecord::Schema.define(version: 2021_01_07_113825) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +21,7 @@ ActiveRecord::Schema.define(version: 2021_01_02_010427) do
     t.string "bot_user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "salt", null: false
   end
 
   create_table "channels", force: :cascade do |t|
@@ -101,4 +101,5 @@ ActiveRecord::Schema.define(version: 2021_01_02_010427) do
     t.string "name", null: false
     t.string "icon_url", null: false
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_01_07_113825) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,5 +102,4 @@ ActiveRecord::Schema.define(version: 2021_01_07_113825) do
     t.string "name", null: false
     t.string "icon_url", null: false
   end
-
 end

--- a/spec/factories/apps.rb
+++ b/spec/factories/apps.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:workspace_id) { 1 }
     sequence(:oauth_bot_token) { ENV["OAUTH_BOT_TOKEN"] }
     sequence(:bot_user_id) { "U01B6RZ33L5" }
+    sequence(:salt) { ENV["SALTED_KEY"] }
   end
 end

--- a/spec/system/channels_spec.rb
+++ b/spec/system/channels_spec.rb
@@ -3,10 +3,12 @@
 require "rails_helper"
 
 RSpec.describe "channels", type: :system do
+  # before do
   before(:context) do
     @user = FactoryBot.create(:user)
     @workspace = FactoryBot.create(:workspace)
     @possession = FactoryBot.create(:possession, user_id: @user.id, workspace_id: @workspace.id)
+    # @appは予約されているのでit内で使う場合は別名で
     @app = FactoryBot.create(:app, workspace_id: @workspace.id)
     @channel = FactoryBot.create(:channel, app_id: @app.id)
     @companion = FactoryBot.create(:companion, app_id: @app.id)

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "messages", type: :system do
     @user = FactoryBot.create(:user)
     @workspace = FactoryBot.create(:workspace)
     @possession = FactoryBot.create(:possession, user_id: @user.id, workspace_id: @workspace.id)
+    # @appは予約されているのでit内で使う場合は別名で
     @app = FactoryBot.create(:app, workspace_id: @workspace.id)
     @channel = FactoryBot.create(:channel, app_id: @app.id)
     @companion = FactoryBot.create(:companion, app_id: @app.id)


### PR DESCRIPTION
* appテーブルにカラム`salt`を追加
* アプリ稼働に必要な環境変数は減らしていない
    * slack apiで実際のtokenを使わないとテストを実行できない為、tokenやsaltの環境変数への設定は必須。暗号化して環境変数に入れるようgithubのREADMEに記述